### PR TITLE
Updating difficulty scale

### DIFF
--- a/src/exercises/any-of.ts
+++ b/src/exercises/any-of.ts
@@ -1,10 +1,10 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: medium
+// difficulty: medium 3/4
 // tags: conditional-types, index-accessed
 
 /**
- * Update `AnyOf` to implement a Python-liked any function in the type system. A
+ * Update `AnyOf` to implement a Python-like any function in the type system. A
  * type takes the Array and returns true if any element of the Array is true. If
  * the Array is empty, return false.
  */

--- a/src/exercises/common-fruits.ts
+++ b/src/exercises/common-fruits.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1
 // tags: utility-types
 
 /**

--- a/src/exercises/concat.ts
+++ b/src/exercises/concat.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1
 // tags: learning-generics, generics-with-constraints, learning-arrays
 
 /**

--- a/src/exercises/deep-partial.ts
+++ b/src/exercises/deep-partial.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: hard
+// difficulty: hard 5
 // tags: conditional-types, mapped-types, utility-types, index-accessed, recursion
 
 /**

--- a/src/exercises/discriminated-union-with-unique-values-to-object.ts
+++ b/src/exercises/discriminated-union-with-unique-values-to-object.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: medium
+// difficulty: medium 3
 // tags: mapped-types, conditional-types, index-accessed, key-remapping, infer, distribution
 
 /**
@@ -24,6 +24,7 @@ type Route =
 
 type RoutesObject = unknown;
 
+// TODO: add more cases
 type cases = [
   Expect<
     Equal<

--- a/src/exercises/dynamic-route.ts
+++ b/src/exercises/dynamic-route.ts
@@ -1,7 +1,7 @@
 import { Equal, Expect } from 'type-testing';
 import { Prettify } from '../prettify';
 
-// difficulty: extreme
+// difficulty: extreme 7
 // tags: conditional-types, mapped-types, utility-types, index-accessed, recursion, learning-arrays, template-literals, distribution, infer
 
 /**

--- a/src/exercises/event-handler.ts
+++ b/src/exercises/event-handler.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: medium
+// difficulty: medium 3/4
 // tags: template-literals, utility-types, generics-with-constraints, distribution
 
 /**

--- a/src/exercises/event-types.ts
+++ b/src/exercises/event-types.ts
@@ -1,6 +1,7 @@
-// difficulty: medium
+// difficulty: medium 3
 // tags: utility-types, generics-with-constraints, index-accessed, learning-generics
 
+// TODO: describe updating the payload type
 /**
  * Update `emit` so that the first argument is the union of types from `Events`
  * and the second argument is the rest of the object except the type property.

--- a/src/exercises/finite-state-machine.ts
+++ b/src/exercises/finite-state-machine.ts
@@ -1,6 +1,9 @@
 // difficulty: easy
 // tags: utility-types
 
+// Add notes that there's type errors below, and there's only 1 line that needs to be changed for FSMConfig
+// Include docs on NoInfer
+
 /**
  * Update the types below so that there's no type errors.
  *

--- a/src/exercises/if.ts
+++ b/src/exercises/if.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1
 // tags: conditional-types, distribution, generics-with-constraints
 
 /**

--- a/src/exercises/infer-in-union-types.ts
+++ b/src/exercises/infer-in-union-types.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 2
 // tags: conditional-types, distribution
 
 /**

--- a/src/exercises/infer-with-raw-values.ts
+++ b/src/exercises/infer-with-raw-values.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1
 // tags: conditional-types, index-accessed, generics-with-constraints
 
 /**

--- a/src/exercises/length-of-tuple.ts
+++ b/src/exercises/length-of-tuple.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1
 // tags: conditional-types, index-accessed, generics-with-constraints, infer, learning-arrays, learning-generics
 
 /**

--- a/src/exercises/mutually-exclusive-properties.ts
+++ b/src/exercises/mutually-exclusive-properties.ts
@@ -1,11 +1,11 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: medium
+// difficulty: medium 2/3
 // tags: mapped-types, index-accessed
 
 /**
  * Update `MutuallyExclusive` so that it unions an separate object type for
- * every property of a single object.
+ * each property of a single object.
  */
 
 interface Attributes {

--- a/src/exercises/my-exclude.ts
+++ b/src/exercises/my-exclude.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 2
 // tags: utility-types, conditional-types, distribution
 
 /**

--- a/src/exercises/narrow-with-arrays.ts
+++ b/src/exercises/narrow-with-arrays.ts
@@ -2,7 +2,7 @@ import { Equal, Expect } from 'type-testing';
 
 // source: https://github.com/total-typescript/advanced-patterns-workshop/blob/main/src/07-challenges/32-narrow-with-arrays.solution.ts
 
-// difficulty: medium
+// difficulty: medium 3
 // tags: utility-types, generics-with-constraints, index-accessed, learning-generics, learning-arrays
 
 /**

--- a/src/exercises/non-empty-array.ts
+++ b/src/exercises/non-empty-array.ts
@@ -1,4 +1,4 @@
-// difficulty: easy
+// difficulty: easy 2/3
 // tags: learning-generics, learning-arrays
 
 /**

--- a/src/exercises/omit-by-type.ts
+++ b/src/exercises/omit-by-type.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: hard
+// difficulty: hard 3/4
 // tags: mapped-types, key-remapping, conditional-types, index-accessed, distribution
 
 /**

--- a/src/exercises/partial-required.ts
+++ b/src/exercises/partial-required.ts
@@ -1,7 +1,8 @@
 import { Expect, Equal } from 'type-testing';
 import { Prettify } from '../prettify';
 
-// difficulty: medium
+// Check me
+// difficulty: medium 3/4
 // tags: utility-types, learning-generics, generics-with-constraints
 
 /**

--- a/src/exercises/printf.ts
+++ b/src/exercises/printf.ts
@@ -1,6 +1,7 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: hard
+// Check me
+// difficulty: hard 5
 // tags: conditional-types, index-accessed, template-literals, infer, recursion
 
 /**

--- a/src/exercises/promise-all.ts
+++ b/src/exercises/promise-all.ts
@@ -1,8 +1,9 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: medium
+// difficulty: medium 3/4
 // tags: utility-types, learning-generics, generics-with-constraints, mapped-types, learning-arrays
 
+// TODO: add notes on Awaited as a hint
 /**
  * Type the function `PromiseAll` that accepts an array of PromiseLike objects,
  * the returning value should be Promise<T> where T is the resolved result

--- a/src/exercises/promise-all.ts
+++ b/src/exercises/promise-all.ts
@@ -1,5 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
+// Check me
 // difficulty: medium 3/4
 // tags: utility-types, learning-generics, generics-with-constraints, mapped-types, learning-arrays
 

--- a/src/exercises/replace.ts
+++ b/src/exercises/replace.ts
@@ -1,5 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
+// Check me
 // difficulty: hard 3/4
 // tags: generics-with-constraints, conditional-types, template-literals, infer
 

--- a/src/exercises/replace.ts
+++ b/src/exercises/replace.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: hard
+// difficulty: hard 3/4
 // tags: generics-with-constraints, conditional-types, template-literals, infer
 
 /**

--- a/src/exercises/reverse-arguments.ts
+++ b/src/exercises/reverse-arguments.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: hard
+// difficulty: hard 4/5
 // tags: utility-types, learning-arrays, conditional-types, infer, recursion, generics-with-constraints
 
 /**

--- a/src/exercises/reverse-arguments.ts
+++ b/src/exercises/reverse-arguments.ts
@@ -1,5 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
+// Check me
 // difficulty: hard 4/5
 // tags: utility-types, learning-arrays, conditional-types, infer, recursion, generics-with-constraints
 

--- a/src/exercises/starts-with.ts
+++ b/src/exercises/starts-with.ts
@@ -1,5 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
+// Check me
 // difficulty: easy 1/2
 // tags: conditional-types, generics-with-constraints, template-literals
 

--- a/src/exercises/starts-with.ts
+++ b/src/exercises/starts-with.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1/2
 // tags: conditional-types, generics-with-constraints, template-literals
 
 /**

--- a/src/exercises/team-members.ts
+++ b/src/exercises/team-members.ts
@@ -1,5 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
+// Check me
 // difficulty: easy 2
 // tags: utility-types
 

--- a/src/exercises/team-members.ts
+++ b/src/exercises/team-members.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 2
 // tags: utility-types
 
 /**

--- a/src/exercises/template-literal-value-extraction.ts
+++ b/src/exercises/template-literal-value-extraction.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1/2
 // tags: conditional-types, infer, template-literals
 
 /**

--- a/src/exercises/template-literal-value-extraction.ts
+++ b/src/exercises/template-literal-value-extraction.ts
@@ -1,5 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
+// Check me
 // difficulty: easy 1/2
 // tags: conditional-types, infer, template-literals
 

--- a/src/exercises/tree-path-array.ts
+++ b/src/exercises/tree-path-array.ts
@@ -1,6 +1,7 @@
 import { Equal, Expect, NotEqual } from 'type-testing';
 
-// difficulty: hard
+// Check me
+// difficulty: hard 5
 // tags: index-accessed, conditional-types, learning-arrays, recursion
 
 /**

--- a/src/exercises/trim-left.ts
+++ b/src/exercises/trim-left.ts
@@ -1,5 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
+// Check me
 // difficulty: medium 2/3
 // tags: recursion, conditional-types, infer, template-literals, distribution
 

--- a/src/exercises/trim-left.ts
+++ b/src/exercises/trim-left.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: medium
+// difficulty: medium 2/3
 // tags: recursion, conditional-types, infer, template-literals, distribution
 
 /**

--- a/src/exercises/tuple-to-object.ts
+++ b/src/exercises/tuple-to-object.ts
@@ -1,5 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
+// Check me
 // difficulty: easy 2/3
 // tags: generics-with-constraints, mapped-types, index-accessed, learning-arrays
 

--- a/src/exercises/tuple-to-object.ts
+++ b/src/exercises/tuple-to-object.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 2/3
 // tags: generics-with-constraints, mapped-types, index-accessed, learning-arrays
 
 /**

--- a/src/exercises/unique-extreme.ts
+++ b/src/exercises/unique-extreme.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: extreme
+// difficulty: extreme 7
 // tags: learning-arrays, generics-with-constraints, index-accessed, recursion, conditional-types, infer, distribution
 
 /**

--- a/src/exercises/unique.ts
+++ b/src/exercises/unique.ts
@@ -1,5 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
+// Check me
 // difficulty: hard 5
 // tags: learning-arrays, generics-with-constraints, index-accessed, recursion, conditional-types, infer, distribution
 

--- a/src/exercises/unique.ts
+++ b/src/exercises/unique.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: hard
+// difficulty: hard 5
 // tags: learning-arrays, generics-with-constraints, index-accessed, recursion, conditional-types, infer, distribution
 
 /**

--- a/src/exercises/utility-types-madness.ts
+++ b/src/exercises/utility-types-madness.ts
@@ -1,5 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
+// Check me
 // difficulty: easy 1
 // tags: utility-types, learning-generics
 

--- a/src/exercises/utility-types-madness.ts
+++ b/src/exercises/utility-types-madness.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1
 // tags: utility-types, learning-generics
 
 /**

--- a/src/solutions/any-of.ts
+++ b/src/solutions/any-of.ts
@@ -2,7 +2,7 @@ import { Expect, Equal } from 'type-testing';
 
 // source: https://github.com/type-challenges/type-challenges/blob/main/questions/00268-easy-if/test-cases.ts
 
-// difficulty: medium
+// difficulty: medium 3
 // tags: conditional-types, index-accessed
 
 /**

--- a/src/solutions/bem-css-selectors.ts
+++ b/src/solutions/bem-css-selectors.ts
@@ -2,7 +2,7 @@ import { Expect, Equal } from 'type-testing';
 
 // source: https://github.com/type-challenges/type-challenges/blob/main/questions/03326-medium-bem-style-string/README.md
 
-// difficulty: easy
+// difficulty: easy 4
 // tags: template-literals, conditional-types, distribution
 
 /**

--- a/src/solutions/cat-dog.ts
+++ b/src/solutions/cat-dog.ts
@@ -1,4 +1,4 @@
-// difficulty: easy
+// difficulty: easy 2
 // tags: learning-generics, utility-types, generics-with-constraints
 
 /**

--- a/src/solutions/common-fruits.ts
+++ b/src/solutions/common-fruits.ts
@@ -1,6 +1,6 @@
 import { Expect, Equal } from 'type-testing';
 
-// difficulty: easy
+// difficulty: easy 1
 // tags: utility-types
 
 /**

--- a/src/solutions/concat.ts
+++ b/src/solutions/concat.ts
@@ -2,7 +2,7 @@ import { Equal, Expect } from 'type-testing';
 
 // source: https://github.com/type-challenges/type-challenges/blob/main/questions/00533-easy-concat/README.md
 
-// difficulty: easy
+// difficulty: easy 1
 // tags: learning-generics, generics-with-constraints, learning-arrays
 
 /**

--- a/src/solutions/deep-partial.ts
+++ b/src/solutions/deep-partial.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: hard
+// difficulty: hard 5
 // tags: conditional-types, mapped-types, utility-types, index-accessed, recursion
 
 /**

--- a/src/solutions/event-handler.ts
+++ b/src/solutions/event-handler.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from 'type-testing';
 
-// difficulty: medium
+// difficulty: medium 3/4
 // tags: template-literals, utility-types, generics-with-constraints, distribution
 
 /**

--- a/src/solutions/promise-all.ts
+++ b/src/solutions/promise-all.ts
@@ -2,7 +2,7 @@ import { Expect, Equal } from 'type-testing';
 
 // source: https://github.com/type-challenges/type-challenges/blob/main/questions/00020-medium-promise-all/README.md
 
-// difficulty: medium
+// difficulty: medium 3/4
 // tags: utility-types, learning-generics, generics-with-constraints, mapped-types, learning-arrays
 
 /**

--- a/src/solutions/tree-path-array.ts
+++ b/src/solutions/tree-path-array.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect, NotEqual } from 'type-testing';
 
-// difficulty: hard
+// difficulty: hard 5
 // tags: index-accessed, conditional-types, learning-arrays, recursion
 
 /**

--- a/src/solutions/tree-path-array.ts
+++ b/src/solutions/tree-path-array.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect, NotEqual } from 'type-testing';
 
-// difficulty: hard 5
+// difficulty: hard
 // tags: index-accessed, conditional-types, learning-arrays, recursion
 
 /**


### PR DESCRIPTION
Switching difficulties to a number scale of 1-5, 7  for extreme.

I think we should go from 1 to 10 instead since we have a lot of values like 2/3, 3/4, 4/5:

1 -> 1
1/2 -> 2
2 -> 3
2/3 -> 4
3 -> 5
3/4 -> 6
4 -> 7
4/5 -> 8
5 -> 9
7 (extreme) -> 10 or 11
